### PR TITLE
Fix for 3.6.1

### DIFF
--- a/release
+++ b/release
@@ -39,7 +39,7 @@ fetchversion()
 
 	VERSION=$2
 
-	if ! echo $VERSION | grep -E '^[0-9]+[.][0-9]+$' > /dev/null; then
+	if ! echo $VERSION | grep -E '^([0-9]+[.]){1,2}[0-9]+$' > /dev/null; then
 		echo "<VERSION> should be in the format <MAJOR>.<MINOR>"
 		usage
 	fi
@@ -204,3 +204,5 @@ main() {
 }
 
 main "$@"
+
+# vim: noet


### PR DESCRIPTION
- with 3.6.1 there might be 3 numbers in the release
- add definition for vim no to extend tabs (to be consistent)